### PR TITLE
[Fix] Timer event was not sent to the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,48 +11,57 @@ Background Timer plugin for Cordova
 #### Automatic Installation using PhoneGap/Cordova CLI (iOS and Android)
 1. Make sure you update your projects to Cordova iOS version 3.5.0+ before installing this plugin.
 
-        cordova platform update android
+```
+cordova platform update android
+```
 
 2. Install this plugin using PhoneGap/Cordova cli:
 
-        cordova plugin add https://github.com/dukhanov/cordova-background-timer.git
+```   
+cordova plugin add https://github.com/dukhanov/cordova-background-timer.git
+```
 		
 ## Usage
 
-#start a timer
-	var eventCallback = function() {
-		// timer event fired
-	}
+### start the plugin
 
-	var successCallback = function() {
-		// timer plugin configured successfully
-	}
-	
-	var errorCallback = function(e) {
-		// an error occurred
-	}
-	
-	var settings = {
-		timerInterval: 60000, // interval between ticks of the timer in milliseconds (Default: 60000)
-		startOnBoot: true, // enable this to start timer after the device was restarted (Default: false)
-		stopOnTerminate: true, // set to true to force stop timer in case the app is terminated (User closed the app and etc.) (Default: true)
+```
+var eventCallback = function() {
+	// timer event fired
+}
 
-		hours: 12, // delay timer to start at certain time (Default: -1)
-		minutes: 0, // delay timer to start at certain time (Default: -1)
-	}
+var successCallback = function() {
+	// timer plugin configured successfully
+}
 
-	window.BackgroundTimer.onTimerEvent(eventCallback); // subscribe on timer event
-	// timer will start at 12:00
-    window.BackgroundTimer.start(successCallback, errorCallback, settings);
-	
+var errorCallback = function(e) {
+	// an error occurred
+}
+
+var settings = {
+	timerInterval: 60000, // interval between ticks of the timer in milliseconds (Default: 60000)
+	startOnBoot: true, // enable this to start timer after the device was restarted (Default: false)
+	stopOnTerminate: true, // set to true to force stop timer in case the app is terminated (User closed the app and etc.) (Default: true)
+
+	hours: 12, // delay timer to start at certain time (Default: -1)
+	minutes: 0, // delay timer to start at certain time (Default: -1)
+}
+
+window.BackgroundTimer.onTimerEvent(eventCallback); // subscribe on timer event
+// timer will start at 12:00
+window.BackgroundTimer.start(successCallback, errorCallback, settings);
+
+```	
 #stop a timer
 
-	var successCallback = function(){
-		// timer tick
-	}
-	
-	var errorCallback = function(e){
-		// an error occurred
-	}
-	
-	window.BackgroundTimer.stop(successCallback, errorCallback);
+```
+var successCallback = function(){
+	// timer tick
+}
+
+var errorCallback = function(e){
+	// an error occurred
+}
+
+window.BackgroundTimer.stop(successCallback, errorCallback);
+```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.0.3",
+    "version": "0.0.4",
     "name": "com.skycom.cordova.background-timer",
     "cordova_name": "BackgroundTimer",
     "description": "BackgroundTimer Plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.skycom.cordova.background-timer"
-    version="0.0.3">
+    version="0.0.4">
 
     <name>BackgroundTimer</name>
     <description></description>

--- a/src/android/TimerEventReceiver.java
+++ b/src/android/TimerEventReceiver.java
@@ -14,11 +14,9 @@ public class TimerEventReceiver extends BroadcastReceiver {
     
     @Override
     public void onReceive(Context context, Intent intent) {
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-        PluginSettings.initialize(preferences);
-        Log.i(TAG, "TIMER TICK");
+        Log.i(TAG, "timer tick");
 
-        if (PluginSettings.isStopOnTerminate() || !PluginSettings.isEnabled()) return;
+        if (!PluginSettings.isEnabled()) return;
 
         EventBus bus = EventBus.getDefault();
         if (bus.hasSubscriberForEvent(TimerEvent.class)) {


### PR DESCRIPTION
Fixed:
- timer event was not sent to the plugin class
- formatted readme file

Updated:
- bump the version number